### PR TITLE
Disable token automatic removal

### DIFF
--- a/gw2-fetch/src/controllers/ping-controller.js
+++ b/gw2-fetch/src/controllers/ping-controller.js
@@ -93,13 +93,13 @@ function PingController(env, axios, models, fetchGw2) {
 			})
 			.catch(function (response) {
 				if (response.status === 400 || response.status === 401) {
-					console.error('Recieved ' + response.status + ' during fetch @ ' + new Date().toGMTString() + ', removing token.');
-					return models.Gw2ApiToken
-						.destroy({
-							where: {
-								token: token
-							}
-						});
+					console.error('Recieved ' + response.status + ' during fetch @ ' + new Date().toGMTString() + ', removing token (disabled).');
+					// return models.Gw2ApiToken
+					// 	.destroy({
+					// 		where: {
+					// 			token: token
+					// 		}
+					// 	});
 				}
 
 				console.error('Problem fetching token, recieved status of ' + response.status + ' with message ' + response.data + ' @ ' + new Date().toGMTString());

--- a/gw2-fetch/src/controllers/ping-controller.js
+++ b/gw2-fetch/src/controllers/ping-controller.js
@@ -100,6 +100,7 @@ function PingController(env, axios, models, fetchGw2) {
 					// 			token: token
 					// 		}
 					// 	});
+					return;
 				}
 
 				console.error('Problem fetching token, recieved status of ' + response.status + ' with message ' + response.data + ' @ ' + new Date().toGMTString());


### PR DESCRIPTION
- Turns off token removal from the fetch container as we're receiving 400 responses when we shouldn't.